### PR TITLE
make the code more flexible for differential fits

### DIFF
--- a/macro/configs/config_fit_fwd.yml
+++ b/macro/configs/config_fit_fwd.yml
@@ -49,6 +49,19 @@ fit:
   min_jpsi_rap : -4
   max_jpsi_rap : -2.7
 
+  min_jpsi_pt : 0
+  max_jpsi_pt : 100
+
+  min_d0_rap : -0.6
+  max_d0_rap : 0.6
+
+  min_d0_pt : 0.5
+  max_d0_pt : 100
+
+  min_dRap : 0
+  max_dRap : 100
+
+
   norm_par_sig_name: [nJPsiD0, nBkgJPsi, nBkgD0, nBkgBkg, rPsi2sJPsi]
   norm_par_sig_val: [5000, 10000, 2000, 10000, 0.023]
   norm_par_sig_lw_lim: [50, 1000, 20, 100, 0.02]

--- a/macro/configs/config_fit_fwd_weighted.yml
+++ b/macro/configs/config_fit_fwd_weighted.yml
@@ -45,6 +45,19 @@ fit:
 
   min_jpsi_rap : -4
   max_jpsi_rap : -2.7
+
+  min_jpsi_pt : 0
+  max_jpsi_pt : 100
+
+  min_d0_rap : -0.6
+  max_d0_rap : 0.6
+
+  min_d0_pt : 0.5
+  max_d0_pt : 100
+
+  min_dRap : 3
+  max_dRap : 100
+  
   
   norm_par_sig_name: [nJPsiD0, nBkgJPsi, nBkgD0, nBkgBkg, rPsi2sJPsi]
   norm_par_sig_val: [5000, 10000, 2000, 10000, 0.023]

--- a/macro/configs/config_fit_mid.yml
+++ b/macro/configs/config_fit_mid.yml
@@ -56,6 +56,18 @@ fit:
   min_jpsi_rap : -0.9
   max_jpsi_rap : 0.9
 
+  min_jpsi_pt : 0
+  max_jpsi_pt : 100
+
+  min_d0_rap : -0.6
+  max_d0_rap : 0.6
+
+  min_d0_pt : 0.5
+  max_d0_pt : 100
+
+  min_dRap : 0
+  max_dRap : 100
+
   norm_par_sig_name: [nJPsiD0, nPsi2SD0, nBkgJPsi, nBkgPsi2S, nBkgD0, nBkgBkg]
   norm_par_sig_val: [5000, 90, 1000, 100, 2000, 10000]
   norm_par_sig_lw_lim: [50, 10, 10, 10, 20, 100]


### PR DESCRIPTION
instead of saving all cases (kinematics, rapidity gap, weighted/unweighted) with the same naming convention, this allows the code to create different directories (automatically) depending on the rapidity gap and the weighting status and saving the fits (pdf and root output) with all relevant information in the name.
In addition to that, it makes the labels on the plots dynamic and would change when the cuts are changed in the config files